### PR TITLE
feat(render): use compiled JS instead of JSX source

### DIFF
--- a/src/render.test.ts
+++ b/src/render.test.ts
@@ -3,15 +3,18 @@ import { render } from './render';
 
 it('should render a component with function declaration', () => {
   const code = `
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 export default function Test({ title, content }) {
-  return (
-    <div>
-      {title && <h2>{title}</h2>}
-      <div>
-        {content}
-      </div>
-    </div>
-  );
+    return /*#__PURE__*/ _jsxs("div", {
+        children: [
+            title && /*#__PURE__*/ _jsx("h2", {
+                children: title
+            }),
+            /*#__PURE__*/ _jsx("div", {
+                children: content
+            })
+        ]
+    });
 };
 `;
   const props = { title: 'Test Title', content: 'Test Content' };
@@ -21,15 +24,18 @@ export default function Test({ title, content }) {
 
 it('should render a component with arrow function', () => {
   const code = `
-const Test = ({ title, content }) => {
-  return (
-    <div>
-      {title && <h2>{title}</h2>}
-      <div>
-        {content}
-      </div>
-    </div>
-  );
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
+const Test = ({ title, content })=>{
+    return /*#__PURE__*/ _jsxs("div", {
+        children: [
+            title && /*#__PURE__*/ _jsx("h2", {
+                children: title
+            }),
+            /*#__PURE__*/ _jsx("div", {
+                children: content
+            })
+        ]
+    });
 };
 export default Test;
 `;

--- a/src/server.test.ts
+++ b/src/server.test.ts
@@ -7,15 +7,18 @@ describe('POST /render', () => {
   it('should respond with 200 and the correct HTML', async () => {
     const requestPayload: RenderRequest = {
       code: `
+import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 export default function Test({ title, content }) {
-  return (
-    <div>
-      {title && <h2>{title}</h2>}
-      <div>
-        {content}
-      </div>
-    </div>
-  );
+    return /*#__PURE__*/ _jsxs("div", {
+        children: [
+            title && /*#__PURE__*/ _jsx("h2", {
+                children: title
+            }),
+            /*#__PURE__*/ _jsx("div", {
+                children: content
+            })
+        ]
+    });
 };
 `,
       props: {


### PR DESCRIPTION
Switching to working with the already compiled JavaScript code of a component instead of expecting the original JSX source. This will save us a Babel transformation.

What the previous implementation side-stepped was ES6 module imports: I wrote the code thinking that we'd solve that later. Switching to the compiled version, however, instantly introduces this challenge, because we always have at least one import statement:

```javascript
import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
```

All my attempts to make ES6 module imports work failed. So I ended up going with a Babel transform using [`@babel/plugin-transform-modules-commonjs`](https://babeljs.io/docs/babel-plugin-transform-modules-commonjs). If we're happy with this approach, this will work for first-party code component imports as well as for XB's pre-bundled packages, and I think we might be able to make it work for URL imports from, e.g., esm.sh.